### PR TITLE
Remove Quay and GitHub requirements

### DIFF
--- a/base/01-apps/contoso/app/contoso-app-deployment.yaml
+++ b/base/01-apps/contoso/app/contoso-app-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         deploymentconfig: contoso
     spec:
       containers:
-        - image: quay.io/pittar/contoso:latest
+        - image: image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:latest
           imagePullPolicy: Always
           name: contoso
           ports:

--- a/base/01-apps/contoso/app/contoso-app-deployment.yaml
+++ b/base/01-apps/contoso/app/contoso-app-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         deploymentconfig: contoso
     spec:
       containers:
-        - image: image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:latest
+        - image: image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso:latest
           imagePullPolicy: Always
           name: contoso
           ports:

--- a/overlays/non-prod/01-namespaces/contoso-cicd/02-pipelines/build-pipeline.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/02-pipelines/build-pipeline.yaml
@@ -123,84 +123,84 @@ spec:
           value: "$(params.app-name)"
         - name: NAMESPACE
           value: "contoso-test"
-    - name: clone-gitops-repo
-      taskRef:
-        name: git-clone
-        kind: ClusterTask
-      runAfter:
-        - rollout-test
-      workspaces:
-        - name: output
-          workspace: gitops-source
-      params:
-        - name: url
-          value: "$(params.gitops-url)"
-        - name: revision
-          value: "$(params.gitops-revision)"
-        - name: deleteExisting
-          value: "true"
-    - name: branch
-      taskRef:
-        name: git
-      runAfter:
-        - clone-gitops-repo
-      workspaces:
-        - name: source
-          workspace: gitops-source
-      params:
-        - name: commands
-          value: |
-            git checkout -b push-$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)
-    - name: patch-prod
-      taskRef:
-        name: kustomize
-      params:
-        - name: old-image
-          value: contoso
-        - name: new-image
-          value: "quay.io/vazonline/contoso"
-        - name: new-tag
-          value: "$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)"
-        - name: overlaypath
-          value: "overlays/prod/01-namespaces/contoso-prod"
-      runAfter:
-        - branch
-      workspaces:
-        - name: source
-          workspace: gitops-source
-    - name: commit
-      taskRef:
-        name: git
-      runAfter:
-        - patch-prod
-      workspaces:
-        - name: source
-          workspace: gitops-source
-      params:
-        - name: commands
-          value: |
-            tag="$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)"
-            git status
-            cat ~/.gitconfig
-            git config --global user.email "pipeline@redhat.com"
-            git add -u
-            git commit -m "Pushing image image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:$tag to production"
-            git push origin push-$tag
-    - name: prod-pr-deploy
-      taskRef:
-        name: task-create-pr
-        kind: Task
-      runAfter:
-        - commit
-      workspaces:
-        - name: source
-          workspace: gitops-source
-      params:
-        - name: title
-          value: Update image to $(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)
-        - name: github-secret
-          value: github-creds-secret
-        - name: body
-          value: |-
-            Please review the following and accept this PR to rollout to PROD.
+    # - name: clone-gitops-repo
+    #   taskRef:
+    #     name: git-clone
+    #     kind: ClusterTask
+    #   runAfter:
+    #     - rollout-test
+    #   workspaces:
+    #     - name: output
+    #       workspace: gitops-source
+    #   params:
+    #     - name: url
+    #       value: "$(params.gitops-url)"
+    #     - name: revision
+    #       value: "$(params.gitops-revision)"
+    #     - name: deleteExisting
+    #       value: "true"
+    # - name: branch
+    #   taskRef:
+    #     name: git
+    #   runAfter:
+    #     - clone-gitops-repo
+    #   workspaces:
+    #     - name: source
+    #       workspace: gitops-source
+    #   params:
+    #     - name: commands
+    #       value: |
+    #         git checkout -b push-$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)
+    # - name: patch-prod
+    #   taskRef:
+    #     name: kustomize
+    #   params:
+    #     - name: old-image
+    #       value: contoso
+    #     - name: new-image
+    #       value: "quay.io/vazonline/contoso"
+    #     - name: new-tag
+    #       value: "$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)"
+    #     - name: overlaypath
+    #       value: "overlays/prod/01-namespaces/contoso-prod"
+    #   runAfter:
+    #     - branch
+    #   workspaces:
+    #     - name: source
+    #       workspace: gitops-source
+    # - name: commit
+    #   taskRef:
+    #     name: git
+    #   runAfter:
+    #     - patch-prod
+    #   workspaces:
+    #     - name: source
+    #       workspace: gitops-source
+    #   params:
+    #     - name: commands
+    #       value: |
+    #         tag="$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)"
+    #         git status
+    #         cat ~/.gitconfig
+    #         git config --global user.email "pipeline@redhat.com"
+    #         git add -u
+    #         git commit -m "Pushing image image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:$tag to production"
+    #         git push origin push-$tag
+    # - name: prod-pr-deploy
+    #   taskRef:
+    #     name: task-create-pr
+    #     kind: Task
+    #   runAfter:
+    #     - commit
+    #   workspaces:
+    #     - name: source
+    #       workspace: gitops-source
+    #   params:
+    #     - name: title
+    #       value: Update image to $(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)
+    #     - name: github-secret
+    #       value: github-creds-secret
+    #     - name: body
+    #       value: |-
+    #         Please review the following and accept this PR to rollout to PROD.
 

--- a/overlays/non-prod/01-namespaces/contoso-cicd/02-pipelines/build-pipeline.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/02-pipelines/build-pipeline.yaml
@@ -66,7 +66,7 @@ spec:
         kind: ClusterTask
       params:
         - name: IMAGE
-          value: quay.io/vazonline/contoso:latest
+          value: image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:latest
         - name: DOCKERFILE
           value: ./Containerfile
       workspaces:
@@ -83,9 +83,9 @@ spec:
         - build-image
       params:
         - name: src-image
-          value: "quay.io/vazonline/contoso:latest"
+          value: "image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:latest"
         - name: dest-image
-          value: "quay.io/vazonline/contoso"
+          value: "image-registry.openshift-image-registry.svc:5000/petclinic/petclinic"
         - name: dest-tags
           value: "$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid),dev"
     - name: rollout-dev
@@ -107,9 +107,9 @@ spec:
         - rollout-dev
       params:
         - name: src-image
-          value: "quay.io/vazonline/contoso:$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)"
+          value: "image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)"
         - name: dest-image
-          value: "quay.io/vazonline/contoso"
+          value: "image-registry.openshift-image-registry.svc:5000/petclinic/petclinic"
         - name: dest-tags
           value: "test"
     - name: rollout-test
@@ -184,7 +184,7 @@ spec:
             cat ~/.gitconfig
             git config --global user.email "pipeline@redhat.com"
             git add -u
-            git commit -m "Pushing image quay.io/vazonline/contoso:$tag to production"
+            git commit -m "Pushing image image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:$tag to production"
             git push origin push-$tag
     - name: prod-pr-deploy
       taskRef:
@@ -204,17 +204,3 @@ spec:
           value: |-
             Please review the following and accept this PR to rollout to PROD.
 
-            Review any security issues with this image here: https://quay.io/vazonline/contoso:$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)
-
-    # - name: run-database-migrations
-    #   taskRef:
-    #     name: dotnet-cli
-    #     kind: Task
-    #   runAfter:
-    #     - build-image
-    #   workspaces:
-    #     - name: source
-    #       workspace: shared-workspace
-    #   params:
-    #     - name: COMMANDS
-    #       value: ["ef","database","update"]

--- a/overlays/non-prod/01-namespaces/contoso-cicd/02-pipelines/build-pipeline.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/02-pipelines/build-pipeline.yaml
@@ -66,7 +66,7 @@ spec:
         kind: ClusterTask
       params:
         - name: IMAGE
-          value: image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:latest
+          value: image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso:latest
         - name: DOCKERFILE
           value: ./Containerfile
         - name: TLSVERIFY
@@ -85,9 +85,9 @@ spec:
         - build-image
       params:
         - name: src-image
-          value: "image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:latest"
+          value: "image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso:latest"
         - name: dest-image
-          value: "image-registry.openshift-image-registry.svc:5000/petclinic/petclinic"
+          value: "image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso"
         - name: dest-tags
           value: "$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid),dev"
     - name: rollout-dev
@@ -109,9 +109,9 @@ spec:
         - rollout-dev
       params:
         - name: src-image
-          value: "image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)"
+          value: "image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso:$(tasks.generate-id.results.short-commit)-$(tasks.generate-id.results.build-uid)"
         - name: dest-image
-          value: "image-registry.openshift-image-registry.svc:5000/petclinic/petclinic"
+          value: "image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso"
         - name: dest-tags
           value: "test"
     - name: rollout-test

--- a/overlays/non-prod/01-namespaces/contoso-cicd/02-pipelines/build-pipeline.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/02-pipelines/build-pipeline.yaml
@@ -69,6 +69,8 @@ spec:
           value: image-registry.openshift-image-registry.svc:5000/petclinic/petclinic:latest
         - name: DOCKERFILE
           value: ./Containerfile
+        - name: TLSVERIFY
+          value: 'false'
       workspaces:
         - name: source
           workspace: shared-workspace

--- a/overlays/non-prod/01-namespaces/contoso-cicd/04-imagestreams/contoso-imagestream.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/04-imagestreams/contoso-imagestream.yaml
@@ -1,0 +1,12 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: contoso
+    app.kubernetes.io/name: contoso
+    app.openshift.io/runtime: dotnet
+    app.openshift.io/runtime-version: "5"
+  name: contoso
+spec:
+  lookupPolicy:
+    local: false

--- a/overlays/non-prod/01-namespaces/contoso-cicd/04-imagestreams/kustomization.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/04-imagestreams/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - contoso-imagestream.yaml

--- a/overlays/non-prod/01-namespaces/contoso-cicd/05-rbac/01-cicd-image-puller-rolebinding.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/05-rbac/01-cicd-image-puller-rolebinding.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cicd-image-puller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects: []

--- a/overlays/non-prod/01-namespaces/contoso-cicd/05-rbac/02-pipeline-image-builder-rolebinding.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/05-rbac/02-pipeline-image-builder-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-image-builder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-builder
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: contoso-cicd

--- a/overlays/non-prod/01-namespaces/contoso-cicd/05-rbac/kustomization.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/05-rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - 01-cicd-image-puller-rolebinding.yaml

--- a/overlays/non-prod/01-namespaces/contoso-cicd/05-rbac/kustomization.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/05-rbac/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - 01-cicd-image-puller-rolebinding.yaml
+  - 02-pipeline-image-builder-rolebinding.yaml

--- a/overlays/non-prod/01-namespaces/contoso-cicd/cicd-image-puller-rolebinding-patch.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/cicd-image-puller-rolebinding-patch.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /subjects/-
+  value:
+    kind: ServiceAccount
+    name: default
+    namespace: contoso-dev
+- op: add
+  path: /subjects/-
+  value:
+    kind: ServiceAccount
+    name: default
+    namespace: contoso-test

--- a/overlays/non-prod/01-namespaces/contoso-cicd/kustomization.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/kustomization.yaml
@@ -7,6 +7,16 @@ bases:
   - 01-tasks
   - 02-pipelines
 #  - 03-triggers
+  - 04-imagestreams
+  - 05-rbac
 
 resources:
   - pipeline-serviceaccount.yaml
+
+patchesJson6902:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: cicd-image-puller
+    path: cicd-image-puller-rolebinding-patch.yaml

--- a/overlays/non-prod/01-namespaces/contoso-cicd/pipeline-serviceaccount.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-cicd/pipeline-serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pipeline
-secrets:
-  - name: quay-creds-secret
-  - name: github-creds-secret
+#secrets:
+#  - name: quay-creds-secret
+#  - name: github-creds-secret

--- a/overlays/non-prod/01-namespaces/contoso-dev/kustomization.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-dev/kustomization.yaml
@@ -7,6 +7,6 @@ bases:
   - ../../../../base/01-apps/contoso
 
 images:
-  - name: quay.io/vazonline/contoso
-    newName: quay.io/vazonline/contoso
+  - name: image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso
+    newName: image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso
     newTag: dev

--- a/overlays/non-prod/01-namespaces/contoso-test/kustomization.yaml
+++ b/overlays/non-prod/01-namespaces/contoso-test/kustomization.yaml
@@ -7,6 +7,6 @@ bases:
   - ../../../../base/01-apps/contoso
 
 images:
-  - name: quay.io/vazonline/contoso
-    newName: quay.io/vazonline/contoso
+  - name: image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso
+    newName: image-registry.openshift-image-registry.svc:5000/contoso-cicd/contoso
     newTag: test

--- a/pipeline-run/build-and-rollout-pipeline-run.yaml
+++ b/pipeline-run/build-and-rollout-pipeline-run.yaml
@@ -16,7 +16,7 @@ spec:
     - name: "app-name"
       value: "contoso"
     - name: "gitops-url"
-      value: "https://github.com/pittar-sandbox/dotnet-contoso-gitops-developers.git"
+      value: "https://github.com/Gitvazonline/dotnet-contoso-gitops-developers.git"
     - name: "gitops-revision"
       value: "main"
   workspaces:

--- a/pipeline-run/build-and-rollout-pipeline-run.yaml
+++ b/pipeline-run/build-and-rollout-pipeline-run.yaml
@@ -10,7 +10,7 @@ spec:
     name: contoso-devops-pipeline
   params:
     - name: "git-url"
-      value: "https://github.com/pittar-sandbox/dotnet-contoso-app.git"
+      value: "https://github.com/Gitvazonline/dotnet-contoso-app.git"
     - name: "git-revision"
       value: "main"
     - name: "app-name"


### PR DESCRIPTION
Now using internal image registry instead of Quay.  No longer attempting to create a branch and PR in GitOps repo. so no need to include GitHub credentials as a sealed secret.